### PR TITLE
Add eCash support

### DIFF
--- a/context.h
+++ b/context.h
@@ -246,6 +246,7 @@ typedef enum coin_kind_e {
   COIN_KIND_RESISTANCE,
   COIN_KIND_RAVENCOIN,
   COIN_KIND_HYDRA,
+  COIN_KIND_ECASH,
   COIN_KIND_UNUSED
 } coin_kind_t;
 

--- a/handler/get_wallet_public_key.c
+++ b/handler/get_wallet_public_key.c
@@ -97,7 +97,7 @@ WEAK unsigned short handler_get_wallet_public_key(buffer_t *buffer, uint8_t p1,
     return io_send_sw(SW_INCORRECT_P1_P2);
   }
 
-  if (p2 == P2_CASHADDR && COIN_KIND != COIN_KIND_BITCOIN_CASH) {
+  if (p2 == P2_CASHADDR && COIN_KIND != COIN_KIND_BITCOIN_CASH && COIN_KIND != COIN_KIND_ECASH) {
     PRINTF("Wrong P2 value\n");
     return io_send_sw(SW_INCORRECT_P1_P2);
   }

--- a/handler/hash_input_start.c
+++ b/handler/hash_input_start.c
@@ -83,7 +83,7 @@ WEAK unsigned short handler_hash_input_start(buffer_t *buffer, uint8_t p1,
       context.transactionContext.relaxed = 0;
       context.usingSegwit = usingSegwit;
 
-      if (COIN_KIND == COIN_KIND_BITCOIN_CASH) {
+      if ((COIN_KIND == COIN_KIND_BITCOIN_CASH) || (COIN_KIND == COIN_KIND_ECASH)) {
         unsigned char usingCashAddr = (p2 == P2_NEW_SEGWIT_CASHADDR);
         context.usingCashAddr = usingCashAddr;
       } else {

--- a/handler/hash_sign.c
+++ b/handler/hash_sign.c
@@ -117,8 +117,8 @@ WEAK unsigned short handler_hash_sign(buffer_t *buffer, uint8_t p1,
   sighashType = *(parameters++);
   context.transactionSummary.sighashType = sighashType;
 
-  // if bitcoin cash OR forkid is set, then use the fork id
-  if ((COIN_KIND == COIN_KIND_BITCOIN_CASH) || (COIN_FORKID != 0)) {
+  // if bitcoin cash OR eCash or forkid is set, then use the fork id
+  if ((COIN_KIND == COIN_KIND_BITCOIN_CASH) || (COIN_KIND == COIN_KIND_ECASH) || (COIN_FORKID != 0)) {
 #define SIGHASH_FORKID 0x40
     if (sighashType != (SIGHASH_ALL | SIGHASH_FORKID)) {
       context.transactionContext.transactionState = TRANSACTION_NONE;

--- a/utils/cashaddr.c
+++ b/utils/cashaddr.c
@@ -28,6 +28,7 @@
 #include <string.h>
 
 #include "cashaddr.h"
+#include "context.h"
 
 static const char *charset = "qpzry9x8gf2tvdw0s3jn54khce6mua7l";
 
@@ -81,7 +82,12 @@ static int convert_bits(uint8_t *out, size_t *outlen, int outbits,
 
 void create_checksum(uint8_t *payload, size_t payload_length,
                      uint8_t *checksum) {
-  uint8_t *prefix = (uint8_t *)"bitcoincash";
+  uint8_t *prefix;
+  if (COIN_KIND == COIN_KIND_ECASH) {
+    prefix = (uint8_t *)"ecash";
+  } else {
+    prefix = (uint8_t *)"bitcoincash";
+  }
   uint64_t mod = PolyMod(prefix, payload, payload_length);
 
   for (size_t i = 0; i < 8; ++i) {
@@ -120,7 +126,7 @@ int cashaddr_encode(uint8_t *hash, const size_t hash_length, uint8_t *addr,
   convert_bits(payload, &payload_length, 5, tmp, hash_length + 1, 8, 1);
 
   create_checksum(payload, payload_length,
-                  checksum); // Assume prefix is 'bitcoincash'
+                  checksum);
 
   for (i = 0; i < payload_length; ++i) {
     if (*payload >> 5) {

--- a/utils/cashaddr.h
+++ b/utils/cashaddr.h
@@ -29,7 +29,7 @@
 #define CASHADDR_P2PKH 0
 #define CASHADDR_P2SH 1
 
-/** Encode a Bitcoin Cash address
+/** Encode a Bitcoin Cash or eCash address
  *
  *  In:      hash:         Pointer to the hash
  *           hash_length:  Length of hash (bytes). Only 20 bytes (160 bits)


### PR DESCRIPTION
Use the ecash: prefix for eCash, and 2 decimal places for the amount. The current implementation requires access to context in cashaddr to avoid changing the callsites.

# Checklist
- [ ] App update process has been followed: no audit, the change may be trivial enough to skip it?
- [ ] Target branch is `develop` : there is no such branch in this repo
- [ ] Application version has been bumped: I'm assuming this is for the `app-bitcoin` repo, not this submodule

