### PR TITLE
IO revamp adaptation: fixing a freeze on Accept and send

### DIFF
--- a/handler/hash_input_finalize_full.c
+++ b/handler/hash_input_finalize_full.c
@@ -537,7 +537,7 @@ unsigned short handler_hash_input_finalize_full(buffer_t *buffer, uint8_t p1,
   return io_send_response_pointer(G_io_apdu_buffer, context.outLength, sw);
 }
 
-unsigned char user_action(unsigned char confirming) {
+bool user_action(unsigned char confirming) {
   unsigned short sw = SW_OK;
 
   // confirm and finish the apdu exchange //spaghetti
@@ -570,7 +570,7 @@ unsigned char user_action(unsigned char confirming) {
           break;
         } else {
           // Let the UI play
-          return 1;
+          return true;
         }
       } else {
         // Out of data to process, wait for the next call
@@ -587,7 +587,7 @@ unsigned char user_action(unsigned char confirming) {
         sw = SW_INCORRECT_DATA;
       } else {
         // Let the UI play
-        return 1;
+        return true;
       }
     }
 
@@ -615,5 +615,7 @@ unsigned char user_action(unsigned char confirming) {
     // we've finished the processing of the input
     hash_input_finalize_full_reset();
   }
-  return io_send_response_pointer(G_io_apdu_buffer, context.outLength, sw);
+
+  int ret = io_send_response_pointer(G_io_apdu_buffer, context.outLength, sw);
+  return (ret < 0);
 }

--- a/ui/extensions.h
+++ b/ui/extensions.h
@@ -27,7 +27,9 @@ void display_token(void);
 unsigned int finalize_tx(void);
 
 // UI response to btchip to finish the exchange
-unsigned char user_action(unsigned char confirming);
+// returns true if no data has been sent or an error occurred, false in case of
+// success
+bool user_action(unsigned char confirming);
 
 // request the UI to redisplay the idle screen
 void idle(void);


### PR DESCRIPTION
The freeze was provoked by modified `io_send_response_pointer()` behavior  that can now return positive value (number of bytes sent) in case of success. 
Thus ` ui_idle_flow();  // redraw ui` was not called any more. 


Before that was strictly `0` in the case of success. 

As it was before if `io_send_response_pointer()`  fails and returns a value less than `0` `user_action()` will return `true` and `ui_idle_flow();  // redraw ui` won't be called. 

Fixes: https://www.reddit.com/r/ledgerwallet/comments/1mjnqk0/new_firmware_250/

 
# Checklist
<!-- Put an `x` in each box when you have completed the items. -->
- [ ] App update process has been followed <!-- See comment below -->
- [ ] Target branch is `develop` <!-- unless you have a very good reason -->
- [ ] Application version has been bumped <!-- required if your changes are to be deployed -->

<!-- Make sure you followed the process described in https://developers.ledger.com/docs/device-app/deliver/maintenance before opening your Pull Request.
Don't hesitate to contact us directly on Discord if you have any questions ! https://developers.ledger.com/discord -->
